### PR TITLE
Fix API Reference in Transactions League Fetch

### DIFF
--- a/collections/transactionsCollection.js
+++ b/collections/transactionsCollection.js
@@ -77,6 +77,7 @@ TransactionsCollection.prototype.leagueFetch = function(leagueKeys, resources, f
   url += '?format=json';
 
   this
+  .yf
   .api(
     this.yf.GET,
     url,


### PR DESCRIPTION
The leageFetch function was breaking because it was attempting to access the api object on `this` rather than through `this.yf`
